### PR TITLE
Fix an issue with unwanted removal of route

### DIFF
--- a/Sources/UIPilot/UIPilot.swift
+++ b/Sources/UIPilot/UIPilot.swift
@@ -67,12 +67,14 @@ public class UIPilot<T: Equatable>: ObservableObject {
     }
     
     public func onSystemPop() {
-        guard !shouldIgnoreSystemPop, !self._routes.isEmpty else {
+        guard !shouldIgnoreSystemPop else {
             shouldIgnoreSystemPop = false
             return
         }
-        let popped = self._routes.removeLast()
-        logger.log("UIPilot - \(popped) route popped by system")
+        if !self._routes.isEmpty {
+            let popped = self._routes.removeLast()
+            logger.log("UIPilot - \(popped) route popped by system")
+        }
     }
 }
 

--- a/Sources/UIPilot/UIPilot.swift
+++ b/Sources/UIPilot/UIPilot.swift
@@ -14,7 +14,9 @@ public class UIPilot<T: Equatable>: ObservableObject {
     
     var onPush: ((T) -> Void)?
     var onPopLast: ((Int, Bool) -> Void)?
-
+    
+    private var shouldIgnoreSystemPop: Bool = false
+    
     public init(initial: T? = nil, debug: Bool = false) {
         logger = debug ? DebugLog() : EmptyLog()
         logger.log("UIPilot - Pilot Initialized.")
@@ -35,6 +37,7 @@ public class UIPilot<T: Equatable>: ObservableObject {
         if !self._routes.isEmpty {
             let popped = self._routes.removeLast()
             logger.log("UIPilot - \(popped) route popped.")
+            shouldIgnoreSystemPop = true
             onPopLast?(1, animated)
         }
     }
@@ -59,14 +62,17 @@ public class UIPilot<T: Equatable>: ObservableObject {
         let numToPop = (found..<_routes.endIndex).count
         logger.log("UIPilot - Popping \(numToPop) routes")
         _routes.removeLast(numToPop)
+        shouldIgnoreSystemPop = true
         onPopLast?(numToPop, animated)
     }
     
     public func onSystemPop() {
-        if !self._routes.isEmpty {
-            let popped = self._routes.removeLast()
-            logger.log("UIPilot - \(popped) route popped by system")
+        guard !shouldIgnoreSystemPop, !self._routes.isEmpty else {
+            shouldIgnoreSystemPop = false
+            return
         }
+        let popped = self._routes.removeLast()
+        logger.log("UIPilot - \(popped) route popped by system")
     }
 }
 


### PR DESCRIPTION
Hello again :) Created an issue and decided to fix it right away.
I think this flag should be enough, because after any manual call of `pop()` or `popTo()` only one `onSystemPop()` event comes.

Fixes #34 